### PR TITLE
APIパスが古いので修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func init() {
 	}
 
 	fmt.Printf("Hatena ID: %s\n", hatenaId)
-	initialAtomLink = fmt.Sprintf("https://blog.hatena.ne.jp/%s/%s.hateblo.jp/atom/entry", hatenaId, hatenaId)
+	initialAtomLink = fmt.Sprintf("https://blog.hatena.ne.jp/%s/%s.hatenablog.com/atom/entry", hatenaId, hatenaId)
 }
 
 func getXML(url string) (string, error) {


### PR DESCRIPTION
使ってみるにあたって、そのままだと404エラーになったのでID調べてみたところ今は{ブログID}項目が

ブログID
意味:ブログのID
書式:ブログのドメイン (例: example.hatenablog.com)

となっていたので、これに合わせて一応修正しました。
https://developer.hatena.ne.jp/ja/documents/blog/apis/atom